### PR TITLE
Include basic setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,63 @@
-# Python cache files
+# Python files
 
-__pycache__/*
-*/__pycache__/*
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
 
 # Windows image file caches
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 **[Cactus](http://shearofdoom.github.io/Cactus/)** is a simple engine used to build Zork-style adventure games. Cactus is still in it's early stages of development, but will be updated as regularly as possible, and with as many new features as possible. I hope you enjoy Cactus!
 
+## Installation
+
+- Clone the repository
+```shell
+git clone https://github.com/ShearOfDoom/Cactus.git
+```
+- Install
+```shell
+python setup.py install
+```
+
 ## Setup:
 
 Please see our license. **You are required to add attribution** (again, see license for details). By default, this attribution is included in the `about` command.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from setuptools import setup, find_packages
+setup(
+    name='cactus',
+    packages=find_packages(),
+    version='0.2.0a',
+    description='A simple Python engine for creating text-based adventure games.',
+    author='Ethan Bierlein',
+    author_email='',
+    url='https://github.com/ShearOfDoom/Cactus',
+    download_url='https://github.com/ShearOfDoom/Cactus/archive/v0.2.0-alpha.zip',
+    keywords=[],
+    classifiers=[],
+)


### PR DESCRIPTION
#56

I don't know your email, so `author_email` was left blank. I could add this if you tell me, or you can add this yourself after this gets merged.

Do tell me, if there are any other changes you wish regarding this.

Also, it would be great, if you can update the instructions in the docs [here](http://shearofdoom.github.io/Cactus/Docs/v0.2.x-alpha/Installation/) after merging this. I could send a PR for that too, if you want.
